### PR TITLE
fix(db): migrations to remove allauth from db

### DIFF
--- a/backend/django_monolith/backend/settings/auth_conf.py
+++ b/backend/django_monolith/backend/settings/auth_conf.py
@@ -1,3 +1,11 @@
+"""
+Authentication and OAuth Configuration
+
+NOTE: ACCOUNT_* and SOCIALACCOUNT_* settings below are for the custom OAuth
+implementation in the user_auth app, not django-allauth (which was removed in
+commit 7b22b41 in favor of custom models and views).
+"""
+
 import os
 from datetime import timedelta
 

--- a/backend/django_monolith/user_auth/migrations/0003_migrate_allauth_data.py
+++ b/backend/django_monolith/user_auth/migrations/0003_migrate_allauth_data.py
@@ -1,0 +1,94 @@
+# Migration to preserve OAuth user data from django-allauth tables
+# before dropping them in the next migration.
+
+from django.db import migrations
+
+
+def migrate_allauth_data(apps, schema_editor):
+    """
+    Migrates OAuth account data from old django-allauth tables to custom SocialAccount model.
+
+    This migration:
+    1. Checks if old socialaccount_socialaccount table exists
+    2. Migrates OAuth accounts to user_auth_socialaccount
+    3. Handles duplicates gracefully (skip if already exists)
+    4. Preserves provider, uid, and timestamps
+    """
+    # Use raw SQL for migration since allauth tables are not in Django models
+    with schema_editor.connection.cursor() as cursor:
+        # Check if allauth table exists
+        cursor.execute("""
+            SELECT EXISTS (
+                SELECT FROM information_schema.tables
+                WHERE table_schema = 'public'
+                AND table_name = 'socialaccount_socialaccount'
+            );
+        """)
+        table_exists = cursor.fetchone()[0]
+
+        if not table_exists:
+            print("✓ No django-allauth tables found - skipping data migration")
+            return
+
+        # Count existing records
+        cursor.execute("SELECT COUNT(*) FROM socialaccount_socialaccount;")
+        allauth_count = cursor.fetchone()[0]
+        print(f"Found {allauth_count} OAuth accounts in django-allauth table")
+
+        if allauth_count == 0:
+            print("✓ No data to migrate")
+            return
+
+        # Migrate data to user_auth_socialaccount
+        # Use INSERT ... SELECT with WHERE NOT EXISTS to avoid duplicates
+        cursor.execute("""
+            INSERT INTO user_auth_socialaccount
+                (user_id, provider, uid, extra_data, created_at, updated_at)
+            SELECT
+                sa.user_id,
+                sa.provider,
+                sa.uid,
+                COALESCE(sa.extra_data, '{}'::jsonb) as extra_data,
+                COALESCE(sa.date_joined, NOW()) as created_at,
+                COALESCE(sa.last_login, NOW()) as updated_at
+            FROM socialaccount_socialaccount sa
+            WHERE NOT EXISTS (
+                SELECT 1 FROM user_auth_socialaccount usa
+                WHERE usa.provider = sa.provider
+                AND usa.uid = sa.uid
+            );
+        """)
+
+        migrated_count = cursor.rowcount
+        print(f"✓ Migrated {migrated_count} OAuth accounts to user_auth_socialaccount")
+
+        # Verify migration
+        cursor.execute("SELECT COUNT(*) FROM user_auth_socialaccount;")
+        new_count = cursor.fetchone()[0]
+        print(f"✓ Total OAuth accounts in user_auth_socialaccount: {new_count}")
+
+
+def reverse_migrate(apps, schema_editor):
+    """
+    Reverse migration is intentionally minimal.
+
+    We don't attempt to restore data to allauth tables because:
+    1. The next migration drops those tables
+    2. Restoring would require recreating the allauth schema
+    3. The custom model is the source of truth going forward
+    """
+    print("⚠ Reverse migration: data remains in user_auth_socialaccount")
+    print("  (Not attempting to restore django-allauth tables)")
+
+
+class Migration(migrations.Migration):
+    dependencies = [
+        ("user_auth", "0002_emailverificationtoken_passwordresettoken"),
+    ]
+
+    operations = [
+        migrations.RunPython(
+            migrate_allauth_data,
+            reverse_code=reverse_migrate,
+        ),
+    ]

--- a/backend/django_monolith/user_auth/migrations/0004_remove_allauth_tables.py
+++ b/backend/django_monolith/user_auth/migrations/0004_remove_allauth_tables.py
@@ -1,0 +1,84 @@
+# Migration to drop orphaned django-allauth tables from production database.
+# These tables were left behind when django-allauth was removed from the codebase.
+
+from django.db import migrations
+
+
+def drop_allauth_tables(apps, schema_editor):
+    """
+    Drops all django-allauth tables from the database.
+
+    Tables dropped (in dependency-safe order):
+    - socialaccount_socialtoken (OAuth tokens)
+    - socialaccount_socialapp_sites (app-site relationships)
+    - socialaccount_socialapp (OAuth app configurations)
+    - socialaccount_socialaccount (main OAuth accounts - data already migrated)
+    - account_emailconfirmation (email confirmations)
+    - account_emailaddress (email addresses)
+
+    Using CASCADE to handle any remaining foreign key dependencies.
+    """
+    tables_to_drop = [
+        "socialaccount_socialtoken",
+        "socialaccount_socialapp_sites",
+        "socialaccount_socialapp",
+        "socialaccount_socialaccount",
+        "account_emailconfirmation",
+        "account_emailaddress",
+    ]
+
+    with schema_editor.connection.cursor() as cursor:
+        print("Dropping django-allauth tables...")
+
+        for table_name in tables_to_drop:
+            # Check if table exists before dropping
+            cursor.execute(
+                """
+                SELECT EXISTS (
+                    SELECT FROM information_schema.tables
+                    WHERE table_schema = 'public'
+                    AND table_name = %s
+                );
+            """,
+                [table_name],
+            )
+            table_exists = cursor.fetchone()[0]
+
+            if table_exists:
+                cursor.execute(f"DROP TABLE IF EXISTS {table_name} CASCADE;")
+                print(f"  ✓ Dropped table: {table_name}")
+            else:
+                print(f"  - Table not found (already removed): {table_name}")
+
+        print("✓ All django-allauth tables removed successfully")
+
+
+def recreate_allauth_tables(apps, schema_editor):
+    """
+    Reverse migration is NOT implemented.
+
+    Recreating django-allauth tables would require:
+    1. Reinstalling django-allauth
+    2. Running its migrations
+    3. Migrating data back from user_auth_socialaccount
+
+    This is not practical or desirable. If rollback is needed, restore from database backup.
+    """
+    print("⚠ Cannot reverse this migration")
+    print("  To rollback, restore from database backup taken before deployment")
+    raise RuntimeError(
+        "Migration reversal not supported. Restore from database backup instead."
+    )
+
+
+class Migration(migrations.Migration):
+    dependencies = [
+        ("user_auth", "0003_migrate_allauth_data"),
+    ]
+
+    operations = [
+        migrations.RunPython(
+            drop_allauth_tables,
+            reverse_code=recreate_allauth_tables,
+        ),
+    ]


### PR DESCRIPTION
I decided to remove allauth dependency, but in the past, 
there were tables added to the db from that lib. 
They should be removed after this fix