### PR TITLE
fix: add agent dir to the build runtime as well

### DIFF
--- a/backend/mcp_diagrams/Dockerfile
+++ b/backend/mcp_diagrams/Dockerfile
@@ -4,6 +4,7 @@ FROM ghcr.io/astral-sh/uv:python3.13-bookworm-slim@sha256:fcb50226f56cc30eb2d9fa
 WORKDIR /app
 
 COPY pyproject.toml uv.lock ./
+COPY agent/ /app/agent/
 RUN uv sync --group diagram-mcp
 
 # Release


### PR DESCRIPTION
agent dir was not copied during the mcp docker build time