### PR TITLE
feat: add C4 model nodes (Person, Container, Database, System, etc.)

### DIFF
--- a/backend/mcp_diagrams/available_nodes.py
+++ b/backend/mcp_diagrams/available_nodes.py
@@ -1,5 +1,24 @@
 # ruff: noqa
 
+from diagrams.c4 import (
+    Person as C4Person,
+    PersonExt as C4PersonExt,
+    System as C4System,
+    SystemDb as C4SystemDb,
+    SystemExt as C4SystemExt,
+    SystemDbExt as C4SystemDbExt,
+    Container as C4Container,
+    ContainerDb as C4ContainerDb,
+    ContainerQueue as C4ContainerQueue,
+    ContainerExt as C4ContainerExt,
+    Component as C4Component,
+    ComponentDb as C4ComponentDb,
+    ComponentExt as C4ComponentExt,
+    SystemBoundary as C4SystemBoundary,
+    ContainerBoundary as C4ContainerBoundary,
+    Relationship as C4Relationship,
+)
+
 from diagrams.aws.general import (
     InternetAlt2,
     OfficeBuilding,
@@ -338,6 +357,23 @@ from diagrams.saas.payment import (
 
 
 NODE_CATALOG: dict[str, tuple[str, str]] = {
+    # C4 Model
+    "C4Person": ("C4 Model", "A person (user) of the system — internal user"),
+    "C4PersonExt": ("C4 Model", "An external person/user outside the system boundary"),
+    "C4System": ("C4 Model", "A software system — the highest level of abstraction"),
+    "C4SystemDb": ("C4 Model", "A software system represented as a database shape"),
+    "C4SystemExt": ("C4 Model", "An external software system outside the boundary"),
+    "C4SystemDbExt": ("C4 Model", "An external software system shown as a database shape"),
+    "C4Container": ("C4 Model", "A container: application, microservice, serverless function, database, etc."),
+    "C4ContainerDb": ("C4 Model", "A container represented as a database shape"),
+    "C4ContainerQueue": ("C4 Model", "A container represented as a queue/message bus shape"),
+    "C4ContainerExt": ("C4 Model", "An external container outside the system boundary"),
+    "C4Component": ("C4 Model", "A component within a container"),
+    "C4ComponentDb": ("C4 Model", "A component represented as a database shape"),
+    "C4ComponentExt": ("C4 Model", "An external component outside the container boundary"),
+    "C4SystemBoundary": ("C4 Model", "Context manager: groups containers inside a system boundary — use with `with C4SystemBoundary('name'):`"),
+    "C4ContainerBoundary": ("C4 Model", "Context manager: groups components inside a container boundary — use with `with C4ContainerBoundary('name'):`"),
+    "C4Relationship": ("C4 Model", "Labeled relationship/edge between C4 elements — use like `element1 >> C4Relationship('label') >> element2`"),
     # AWS General
     "InternetAlt2": ("AWS General", "Internet or external network endpoint"),
     "OfficeBuilding": ("AWS General", "Office or corporate building"),

--- a/backend/mcp_diagrams/data/user_manual/python_diagrams.md
+++ b/backend/mcp_diagrams/data/user_manual/python_diagrams.md
@@ -7,7 +7,7 @@ Generate Python code using the `diagrams` library to create cloud architecture a
 ## CRITICAL RULES
 
 1. **NO import statements** - All imports are handled externally
-1. **NO with statement** - The Diagram context manager is handled externally
+1. **NO with statement for Diagram** - The top-level `Diagram` context manager is handled externally; `with Cluster(...)` and `with C4SystemBoundary(...)` / `with C4ContainerBoundary(...)` are allowed inside your code
 1. Code will be inserted into this template:
 
 ```python
@@ -134,4 +134,61 @@ with Cluster("inc.2"):
     files = Server("FTP server\\n(Videos)")
 
 cloudrun_import >> Edge(label="Requests") >> files
+```
+
+## C4 Diagrams
+
+Use C4-style diagrams when the request is about **system context**, **container architecture**, or **component relationships** — especially when the user wants clean, readable high-level views (C4 model level 1–3).
+
+### C4 Node Types
+
+C4 nodes take `name`, `technology` (optional), and `description` (optional) keyword arguments:
+
+```
+C4Person(name="...", description="...")
+C4Container(name="...", technology="...", description="...")
+C4SystemBoundary("System Name")   # context manager, like Cluster
+C4Relationship("label")           # used between >> operators, like Edge
+```
+
+### C4 Example: System Context Diagram (Level 1)
+
+**INPUT:** Show how a Personal Banking Customer uses the Internet Banking System. The system sends emails via an Email System and connects to a Mainframe Banking System.
+
+```python
+customer = C4Person(name="Personal Banking\nCustomer", description="A customer\nof the bank")
+email = C4SystemExt(name="E-mail System", description="Microsoft Exchange")
+mainframe = C4SystemExt(name="Mainframe Banking\nSystem", description="Stores all banking\ncustomer data")
+
+with C4SystemBoundary("Internet Banking System"):
+    web_app = C4System(name="Web Application", description="Delivers the static\ncontent and SPA")
+    api = C4System(name="API Application", description="Provides banking\nfunctionality via API")
+    db = C4SystemDb(name="Database", description="Stores user\ncredentials, etc.")
+    api >> C4Relationship("Reads from\nand writes to") >> db
+    web_app >> C4Relationship("Delivers to\ncustomer's browser") >> customer
+
+customer >> C4Relationship("Uses") >> web_app
+customer >> C4Relationship("Uses") >> api
+api >> C4Relationship("Sends email\nusing") >> email
+api >> C4Relationship("Makes API\ncalls to") >> mainframe
+```
+
+### C4 Example: Container Diagram (Level 2)
+
+**INPUT:** Show containers inside the Internet Banking System: a Single-Page App (Angular), an API Application (Java/Spring MVC), and a Database (Oracle). An external customer uses the SPA, which calls the API, which reads/writes to the DB.
+
+```python
+customer = C4Person(name="Personal Banking\nCustomer", description="A customer\nof the bank")
+
+with C4SystemBoundary("Internet Banking System"):
+    spa = C4Container(name="Single-Page App", technology="Angular", description="Provides banking\nfunctionality")
+    api = C4Container(name="API Application", technology="Java/Spring MVC", description="Provides banking\nfunctionality via API")
+    db = C4ContainerDb(name="Database", technology="Oracle", description="Stores user data,\nhashed credentials")
+    queue = C4ContainerQueue(name="Message Bus", technology="RabbitMQ", description="Async event\npublishing")
+
+    spa >> C4Relationship("Makes API\ncalls to") >> api
+    api >> C4Relationship("Reads from\nand writes to") >> db
+    api >> C4Relationship("Publishes\nevents to") >> queue
+
+customer >> C4Relationship("Uses") >> spa
 ```


### PR DESCRIPTION
- Adds all C4 model node types from `diagrams.c4` to `available_nodes.py` (C4-prefixed aliases to avoid naming conflicts) - Updates the `python_diagrams.md` guide with C4 node usage instructions and two complete examples (system context and container diagrams).

Closes #65

Generated with [Claude Code](https://claude.ai/code)