### PR TITLE
fix: add the new lib to monolith dockerfile

### DIFF
--- a/backend/django_monolith/Dockerfile
+++ b/backend/django_monolith/Dockerfile
@@ -5,6 +5,7 @@ WORKDIR /app
 
 COPY pyproject.toml uv.lock ./
 COPY agent/ /app/agent/
+COPY renderer/ /app/renderer/
 RUN uv sync --group django-monolith
 
 FROM python:3.13-slim AS release


### PR DESCRIPTION
Despite the fact that this will not be used in prod, current uv config forces this behaviour. There should be an effort to fix this some day.